### PR TITLE
Feature/add counter metrics for completed and failed jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,28 @@ this can also be triggered manually from the `/discover_queues` endpoint
 
 ## Metrics
 
-| Metric                       | type    | description |
-|------------------------------|---------|-------------|
-| bull_queue_completed         | counter | Total number of completed jobs                          |
+| Metric                       | type    | description                                             |
+| ---------------------------- | ------- | ------------------------------------------------------- |
+| bull_queue_completed         | gauge   | Number of completed jobs (not deleted from Redis yet)   |
 | bull_queue_complete_duration | summary | Processing time for completed jobs                      |
-| bull_queue_active            | counter | Total number of active jobs (currently being processed) |
-| bull_queue_delayed           | counter | Total number of jobs that will run in the future        |
-| bull_queue_failed            | counter | Total number of failed jobs                             |
-| bull_queue_waiting           | counter | Total number of jobs waiting to be processed            |
+| bull_queue_active            | gauge   | Total number of active jobs (currently being processed) |
+| bull_queue_delayed           | gauge   | Total number of jobs that will run in the future        |
+| bull_queue_failed            | gauge   | Number of failed jobs (not deleted from Redis yet)      |
+| bull_queue_waiting           | gauge   | Total number of jobs waiting to be processed            |
+| bull_queue_total_completed   | counter | Total number of completed jobs                          |
+| bull_queue_total_failed      | counter | Total number of failed jobs                             |
 
 ## Kubernetes Usage
 
 ### Environment variables for default docker image
 
-| variable              | default                  | description                                     |
-|-----------------------|--------------------------|-------------------------------------------------|
-| EXPORTER_REDIS_URL    | redis://localhost:6379/0 | Redis uri to connect                            |
-| EXPORTER_PREFIX       | bull                     | prefix for queues                               |
-| EXPORTER_STAT_PREFIX  | bull_queue_              | prefix for exported metrics                     |
-| EXPORTER_QUEUES       | -                        | a space separated list of queues to check       |
-| EXPORTER_AUTODISCOVER | -                        | set to '0' or 'false' to disable queue discovery|
+| variable              | default                  | description                                      |
+| --------------------- | ------------------------ | ------------------------------------------------ |
+| EXPORTER_REDIS_URL    | redis://localhost:6379/0 | Redis uri to connect                             |
+| EXPORTER_PREFIX       | bull                     | prefix for queues                                |
+| EXPORTER_STAT_PREFIX  | bull_queue_              | prefix for exported metrics                      |
+| EXPORTER_QUEUES       | -                        | a space separated list of queues to check        |
+| EXPORTER_AUTODISCOVER | -                        | set to '0' or 'false' to disable queue discovery |
 
 
 ### Example deployment

--- a/__tests__/__snapshots__/queueGauges.ts.snap
+++ b/__tests__/__snapshots__/queueGauges.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should list 1 active job 1`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
 
@@ -16,18 +16,24 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 1
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
 "
 `;
 
 exports[`should list 1 active job 2`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 1
 
@@ -42,18 +48,24 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"2dc07c0ff9d27ef5\\"} 0
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
 "
 `;
 
 exports[`should list 1 completed job 1`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"7cc276b43bb43656\\"} 1
 
@@ -68,18 +80,25 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"7cc276b43bb43656\\"} 0
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"7cc276b43bb43656\\"} 0
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"7cc276b43bb43656\\"} 0
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"7cc276b43bb43656\\"} 0
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
+test_stat_total_completed{prefix=\\"test-queue\\",queue=\\"7cc276b43bb43656\\"} 1
 "
 `;
 
 exports[`should list 1 completed job with delay 1`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"672d03e07bff9cd3\\"} 1
 
@@ -103,18 +122,24 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"672d03e07bff9cd3\\"} 0
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"672d03e07bff9cd3\\"} 0
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"672d03e07bff9cd3\\"} 0
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"672d03e07bff9cd3\\"} 0
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
 "
 `;
 
 exports[`should list 1 delayed job 1`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"4f2249f79c9d68b5\\"} 0
 
@@ -129,18 +154,24 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"4f2249f79c9d68b5\\"} 0
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"4f2249f79c9d68b5\\"} 1
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"4f2249f79c9d68b5\\"} 0
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"4f2249f79c9d68b5\\"} 0
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
 "
 `;
 
 exports[`should list 1 failed job 1`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"dd304535bf11c117\\"} 0
 
@@ -155,18 +186,25 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"dd304535bf11c117\\"} 0
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"dd304535bf11c117\\"} 0
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"dd304535bf11c117\\"} 1
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"dd304535bf11c117\\"} 0
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+test_stat_total_failed{prefix=\\"test-queue\\",queue=\\"dd304535bf11c117\\"} 1
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
 "
 `;
 
 exports[`should list 1 queued job 1`] = `
-"# HELP test_stat_completed Number of completed messages
+"# HELP test_stat_completed Number of completed messages (not yet deleted)
 # TYPE test_stat_completed gauge
 test_stat_completed{prefix=\\"test-queue\\",queue=\\"54cceb2dc1d55935\\"} 0
 
@@ -181,12 +219,18 @@ test_stat_active{prefix=\\"test-queue\\",queue=\\"54cceb2dc1d55935\\"} 0
 # TYPE test_stat_delayed gauge
 test_stat_delayed{prefix=\\"test-queue\\",queue=\\"54cceb2dc1d55935\\"} 0
 
-# HELP test_stat_failed Number of failed messages
+# HELP test_stat_failed Number of failed messages (not yet deleted)
 # TYPE test_stat_failed gauge
 test_stat_failed{prefix=\\"test-queue\\",queue=\\"54cceb2dc1d55935\\"} 0
 
 # HELP test_stat_waiting Number of waiting messages
 # TYPE test_stat_waiting gauge
 test_stat_waiting{prefix=\\"test-queue\\",queue=\\"54cceb2dc1d55935\\"} 1
+
+# HELP test_stat_total_failed Total number of failed messages
+# TYPE test_stat_total_failed counter
+
+# HELP test_stat_total_completed Total number of completed messages
+# TYPE test_stat_total_completed counter
 "
 `;

--- a/__tests__/create.util.ts
+++ b/__tests__/create.util.ts
@@ -9,9 +9,10 @@ export interface TestData {
   prefix: string;
   guages: QueueGauges;
   registry: Registry;
+  metricsPrefix: string;
 }
 
-export function makeQueue(name: string = 'TestQueue', prefix: string = 'test-queue'): TestData {
+export function makeQueue(name: string = 'TestQueue', prefix: string = 'test-queue', metricsPrefix: string = 'test_stat_'): TestData {
 
   const registry = new Registry();
   const queue = new Bull(name, { prefix });
@@ -21,6 +22,7 @@ export function makeQueue(name: string = 'TestQueue', prefix: string = 'test-que
     queue,
     prefix,
     registry,
-    guages: makeGuages('test_stat_', [registry]),
+    metricsPrefix,
+    guages: makeGuages(metricsPrefix, [registry]),
   };
 }

--- a/__tests__/metricsCollector.ts
+++ b/__tests__/metricsCollector.ts
@@ -1,0 +1,52 @@
+import { logger } from '../src/logger';
+import { MetricCollector } from '../src/metricCollector';
+import { makeQueue } from './create.util';
+import promClient from 'prom-client';
+
+
+describe('metricsCollector', () => {
+  const REDIS_TEST_URL = 'redis://127.0.0.1:6379';
+  let testData: any;
+  let collector: MetricCollector;
+  beforeEach(async () => {
+    testData = makeQueue();
+    collector = new MetricCollector([], {
+      logger,
+      metricPrefix: testData.metricsPrefix,
+      redis: REDIS_TEST_URL,
+      prefix: testData.prefix,
+      autoDiscover: false,
+    });
+
+    await collector.discoverAll();
+    collector.collectJobCompletions();
+  });
+
+  afterEach(async () => {
+    await collector.close();
+    await testData.queue.clean(0, 'completed');
+    await testData.queue.clean(0, 'active');
+    await testData.queue.clean(0, 'delayed');
+    await testData.queue.clean(0, 'failed');
+    await testData.queue.empty();
+    await testData.queue.close();
+  });
+
+  it('should list 1 completed job', async () => {
+    const {
+      queue,
+    } = testData;
+
+    queue.process(async () => {
+    });
+
+    const job1 = (await queue.add({ a: 1 }));
+    const job2 = (await queue.add({ a: 2 }));
+    await job1.finished();
+    await job2.finished();
+
+    const metrics = promClient.register.metrics();
+
+    expect(metrics).toMatch(/^test_stat_total_completed{prefix="test-queue",queue="TestQueue"} 2$/m);
+  });
+});

--- a/__tests__/metricsCollector.ts
+++ b/__tests__/metricsCollector.ts
@@ -1,7 +1,7 @@
 import { logger } from '../src/logger';
 import { MetricCollector } from '../src/metricCollector';
 import { makeQueue } from './create.util';
-import promClient from 'prom-client';
+import promClient, { Registry } from 'prom-client';
 
 
 describe('metricsCollector', () => {
@@ -23,6 +23,7 @@ describe('metricsCollector', () => {
   });
 
   afterEach(async () => {
+    (testData.registry as Registry).clear();
     await collector.close();
     await testData.queue.clean(0, 'completed');
     await testData.queue.clean(0, 'active');
@@ -32,7 +33,7 @@ describe('metricsCollector', () => {
     await testData.queue.close();
   });
 
-  it('should list 1 completed job', async () => {
+  it('should list 2 total completed job', async () => {
     const {
       queue,
     } = testData;
@@ -40,13 +41,46 @@ describe('metricsCollector', () => {
     queue.process(async () => {
     });
 
+    const metricCollected = new Promise((resolve) => {
+      collector.registerJobCompletionCollectedHandler(() => {
+        resolve();
+      });
+    });
+
     const job1 = (await queue.add({ a: 1 }));
     const job2 = (await queue.add({ a: 2 }));
     await job1.finished();
     await job2.finished();
 
+    await metricCollected;
+
     const metrics = promClient.register.metrics();
 
     expect(metrics).toMatch(/^test_stat_total_completed{prefix="test-queue",queue="TestQueue"} 2$/m);
+  });
+
+  it('should list 1 total failed job', async () => {
+    const {
+      queue,
+    } = testData;
+
+    queue.process(async () => {
+      throw new Error('expected');
+    });
+
+    const metricCollected = new Promise((resolve) => {
+      collector.registerJobFailureCollectedHandler(() => {
+        resolve();
+      });
+    });
+
+    const job = (await queue.add({ a: 1 }));
+    await expect(job.finished()).rejects.toThrow(/expected/);
+
+    await metricCollected;
+
+    const metrics = promClient.register.metrics();
+
+    expect(metrics).toMatch(/^test_stat_total_failed{prefix="test-queue",queue="TestQueue"} 1$/m);
   });
 });

--- a/__tests__/queueGauges.ts
+++ b/__tests__/queueGauges.ts
@@ -1,6 +1,11 @@
 import * as bull from 'bull';
 
-import { getJobCompleteStats, getStats } from '../src/queueGauges';
+import {
+  getJobCompleteStats,
+  getStats,
+  incrementJobTotalCompletedCounter,
+  incrementJobTotalFailedCounter
+} from '../src/queueGauges';
 
 import { TestData } from './create.util';
 import { getCurrentTestHash } from './setup.util';
@@ -57,6 +62,8 @@ it('should list 1 completed job', async () => {
 
   await getStats(prefix, name, queue, guages);
   await getJobCompleteStats(prefix, name, job, guages);
+  await incrementJobTotalCompletedCounter(prefix, name, guages);
+
 
   expect(registry.metrics()).toMatchSnapshot();
 });
@@ -106,6 +113,8 @@ it('should list 1 failed job', async () => {
   await expect(job.finished()).rejects.toThrow(/expected/);
 
   await getStats(prefix, name, queue, guages);
+
+  await incrementJobTotalFailedCounter(prefix, name, guages);
 
   expect(registry.metrics()).toMatchSnapshot();
 });

--- a/src/metricCollector.ts
+++ b/src/metricCollector.ts
@@ -173,6 +173,8 @@ export class MetricCollector {
   }
 
   public async close(): Promise<void> {
+    globalRegister.clear();
+
     this.defaultRedisClient.disconnect();
 
     for (const redisClient of this.queueRedisClients) {

--- a/src/queueGauges.ts
+++ b/src/queueGauges.ts
@@ -1,5 +1,5 @@
 import bull from 'bull';
-import { Gauge, Registry, Summary } from 'prom-client';
+import { Gauge, Registry, Summary, Counter } from 'prom-client';
 
 type LabelsT = 'queue' | 'prefix';
 export interface QueueGauges {
@@ -9,6 +9,8 @@ export interface QueueGauges {
   failed: Gauge<LabelsT>;
   waiting: Gauge<LabelsT>;
   completeSummary: Summary<LabelsT>;
+  totalFailed: Counter<LabelsT>;
+  totalCompleted: Counter<LabelsT>;
 }
 
 export function makeGuages(statPrefix: string, registers: Registry[]): QueueGauges {
@@ -16,7 +18,7 @@ export function makeGuages(statPrefix: string, registers: Registry[]): QueueGaug
     completed: new Gauge({
       registers,
       name: `${statPrefix}completed`,
-      help: 'Number of completed messages',
+      help: 'Number of completed messages (not yet deleted)',
       labelNames: ['queue', 'prefix'],
     }),
     completeSummary: new Summary({
@@ -42,13 +44,25 @@ export function makeGuages(statPrefix: string, registers: Registry[]): QueueGaug
     failed: new Gauge({
       registers,
       name: `${statPrefix}failed`,
-      help: 'Number of failed messages',
+      help: 'Number of failed messages (not yet deleted)',
       labelNames: ['queue', 'prefix'],
     }),
     waiting: new Gauge({
       registers,
       name: `${statPrefix}waiting`,
       help: 'Number of waiting messages',
+      labelNames: ['queue', 'prefix'],
+    }),
+    totalFailed: new Counter({
+      registers,
+      name: `${statPrefix}total_failed`,
+      help: 'Total number of failed messages',
+      labelNames: ['queue', 'prefix'],
+    }),
+    totalCompleted: new Counter({
+      registers,
+      name: `${statPrefix}total_completed`,
+      help: 'Total number of completed messages',
       labelNames: ['queue', 'prefix'],
     }),
   };
@@ -60,6 +74,16 @@ export async function getJobCompleteStats(prefix: string, name: string, job: bul
   }
   const duration = job.finishedOn - job.processedOn!;
   gauges.completeSummary.observe({ prefix, queue: name }, duration);
+}
+
+export async function incrementJobTotalCompletedCounter(prefix: string, name: string, gauges: QueueGauges): Promise<void> {
+
+  gauges.totalCompleted.inc({ prefix, queue: name }, 1);
+}
+
+export async function incrementJobTotalFailedCounter(prefix: string, name: string, gauges: QueueGauges): Promise<void> {
+
+  gauges.totalFailed.inc({ prefix, queue: name }, 1);
 }
 
 export async function getStats(prefix: string, name: string, queue: bull.Queue, gauges: QueueGauges): Promise<void> {


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
This pull request adds new queue metrics `total_completed` and `total_failed`. Type of this metrics is [counter](https://prometheus.io/docs/concepts/metric_types/#counter).

### This is a 
<!-- Pick One -->
- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if nessesary  -->
   - [x] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [x] `package.json` (renovate bot should handle all routine updates)

   - [x] `package-lock.json` (Should not exist as this project uses yarn)
   
   - [x] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [x] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
